### PR TITLE
v1.0.0: remove deprecated options

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,6 @@ OPTIONS
     --user <username>  defaults to 'aj'
     --workdir <dirpath>  where the command runs, defaults to current directory
 
-DEPRECATED (DO NOT USE)
-    --system  alias of --daemon, for compatibility
-    --username  alias of --user, for compatibility
-    --groupname  alias of --group, for compatibility
-
 EXAMPLES
     caddy:   serviceman add -- caddy run --envfile ./.env --config ./Caddyfile --adapter caddyfile
     node:    serviceman add --workdir . --name 'api' -- node ./server.js

--- a/bin/serviceman
+++ b/bin/serviceman
@@ -4,8 +4,8 @@ set -e
 set -u
 
 g_year='2024'
-g_version='v0.9.8'
-g_date='2026-04-20T23:53-06:00'
+g_version='v1.0.0'
+g_date='2026-04-21T00:28-06:00'
 g_license='MPL-2.0'
 
 g_scriptdir="$(dirname "${0}")"

--- a/bin/serviceman
+++ b/bin/serviceman
@@ -101,11 +101,6 @@ fn_add_help() { (
     echo "        NOPASSWD: /sbin/rc-service, /sbin/rc-update  # OpenRC (Alpine, Gentoo, Devuan)"
     echo "        NOPASSWD: /usr/bin/systemctl                  # systemd"
     echo ""
-    echo "DEPRECATED (DO NOT USE)"
-    echo "    --system  alias of --daemon, for compatibility"
-    echo "    --username  alias of --user, for compatibility"
-    echo "    --groupname  alias of --group, for compatibility"
-    echo ""
     echo "EXAMPLES"
     echo "    caddy:   serviceman add -- caddy run --envfile ./.env --config ./Caddyfile --adapter caddyfile"
     echo "    node:    serviceman add --workdir . --name 'api' -- node ./server.js"
@@ -189,63 +184,6 @@ cmd_add() { (
                 b_opt_arg="$(printf '%s' "${b_arg}" | cut -d= -f2-)"
                 b_arg="$(printf '%s' "${b_arg}" | cut -d= -f1)"
                 ;;
-        esac
-
-        # transitional
-        case "${b_arg}" in
-            -help)
-                echo "warn: -help should be --help"
-                b_arg='--help'
-                ;;
-            -cap-net-bind | --cap-net-bind)
-                echo "warn: --cap-net-bind is now the default, use --no-cap-net-bind to disable"
-                b_arg='--no-cap-net-bind'
-                ;;
-            -dryrun)
-                echo "warn: -dryrun should be --dryrun"
-                b_arg='--dryrun'
-                ;;
-            -force)
-                echo "warn: -force should be --force"
-                b_arg='--force'
-                ;;
-            -system | --system)
-                echo "warn: --system is now --daemon"
-                b_arg='--daemon'
-                ;;
-            -name)
-                echo "warn: -name should be --name"
-                b_arg='--name'
-                ;;
-            -desc)
-                echo "warn: -desc should be --desc"
-                b_arg='--desc'
-                ;;
-            -groupname | --groupname)
-                echo "warn: --groupname should be --group"
-                b_arg='--group'
-                ;;
-            -rdns)
-                echo "warn: -rdns should be --rdns"
-                b_arg='--rdns'
-                ;;
-            -title)
-                echo "warn: -title should be --title"
-                b_arg='--title'
-                ;;
-            -url)
-                echo "warn: -url should be --url"
-                b_arg='--url'
-                ;;
-            -user | -username | --username)
-                echo "warn: --username should be --user"
-                b_arg='--user'
-                ;;
-            -workdir)
-                echo "warn: -workdir should be --workdir"
-                b_arg='--workdir'
-                ;;
-            *) ;;
         esac
 
         case "${b_arg}" in


### PR DESCRIPTION
Dropping support for v0.8.0 options that were deprecated in v1.0.0:
- drop go-style flags `-name` in favor of *nix-style flags `--name`
- rename `--system` to `--daemon`
- rename `--username` to `--user`
- old `--user` became `--agent`