### PR TITLE
fix(openrc): stop leaves child process running, respawn-period warning

### DIFF
--- a/bin/serviceman
+++ b/bin/serviceman
@@ -586,7 +586,8 @@ cmd_add() { (
             "${b_workdir}" \
             "${b_path}" \
             "${b_cap_net_bind}" \
-            "${b_dryrun}"
+            "${b_dryrun}" \
+            "${b_cmdpath}"
         return
     fi
 
@@ -999,6 +1000,7 @@ fn_openrc_add() { (
     a_path="${10}"
     a_cap_net_bind="${11}"
     a_dryrun="${12}"
+    a_cmd="${13}"
 
     if test -n "${a_login_agent}"; then
         echo >&2 "error: '--agent' has no meaning for OpenRC - it doesn't support user launchers"
@@ -1021,7 +1023,8 @@ fn_openrc_add() { (
         sed "s;EX_GROUP;${a_group};g" |
         sed "s;EX_WORKDIR;${a_workdir};g" |
         sed "s;EX_PATH;${a_path};g" |
-        sed "s;EX_SUPERVISE_ARGS;${b_supervise_args};g" > "${a_name}"
+        sed "s;EX_SUPERVISE_ARGS;${b_supervise_args};g" |
+        sed "s;EX_CMD;${a_cmd};g" > "${a_name}"
 
     if test -n "${a_dryrun}"; then
         cat "${a_name}"

--- a/bin/serviceman
+++ b/bin/serviceman
@@ -4,8 +4,8 @@ set -e
 set -u
 
 g_year='2024'
-g_version='v0.9.5'
-g_date='2024-12-23T00:25:00-07:00'
+g_version='v0.9.6'
+g_date='2026-04-20T23:07-06:00'
 g_license='MPL-2.0'
 
 g_scriptdir="$(dirname "${0}")"

--- a/share/serviceman/template.openrc
+++ b/share/serviceman/template.openrc
@@ -30,6 +30,7 @@ start() {
         --pidfile /run/${RC_SVCNAME}.pid \
         --respawn-delay 5 \
         --respawn-max 51840 \
+        --respawn-period 259201 \
         EX_SUPERVISE_ARGS \
         -- \
         EX_POSIX_ARGS
@@ -40,5 +41,8 @@ stop() {
     ebegin "Stopping ${name}"
     supervise-daemon ${name} --stop \
         --pidfile /run/${RC_SVCNAME}.pid
+    start-stop-daemon --stop --quiet \
+        --retry TERM/20/KILL/1 \
+        --exec 'EX_CMD' 2>/dev/null || true
     eend $?
 }


### PR DESCRIPTION
## Problem

`rc-service <name> restart` consistently leaves the supervised child process running and holding its port. On restart, the new supervisor can't bind and enters a respawn loop (`listen tcp :PORT: bind: address already in use`).

Root cause: `supervise-daemon --stop` kills the supervisor process (by pidfile) but does not send any signal to the supervised child. The child keeps running independently.

Additionally, `supervise-daemon` emits a warning at startup:
```
supervise-daemon: Please increase the value of --respawn-period to more than 259200 to avoid infinite respawning
```
because `--respawn-period` was unset, which causes the respawn counter to never accumulate to `--respawn-max`.

## Fix

1. Add `start-stop-daemon --stop --retry TERM/20/KILL/1 --exec 'EX_CMD'` to `stop()` after stopping the supervisor. Gives the child up to 20 seconds to exit gracefully, then SIGKILL.

2. Add `--respawn-period 259201` (= `respawn-delay × respawn-max + 1 = 5 × 51840 + 1`) to silence the warning. With this value: a service crashing continuously for ~3 days gives up; one that occasionally succeeds retries indefinitely.

## Test plan

- [x] `rc-service <name> start` — no respawn-period warning
- [x] `rc-service <name> restart` — old child exits, new child starts cleanly on the same port
- [x] `rc-service <name> stop` — no orphan process left holding the port