### PR TITLE
fix(openrc): add ulimit -n 1048576 to match systemd LimitNOFILE

### DIFF
--- a/bin/serviceman
+++ b/bin/serviceman
@@ -4,8 +4,8 @@ set -e
 set -u
 
 g_year='2024'
-g_version='v0.9.6'
-g_date='2026-04-20T23:07-06:00'
+g_version='v0.9.7'
+g_date='2026-04-20T00:00-06:00'
 g_license='MPL-2.0'
 
 g_scriptdir="$(dirname "${0}")"

--- a/share/serviceman/template.openrc
+++ b/share/serviceman/template.openrc
@@ -14,6 +14,7 @@ depend() {
 }
 
 start_pre() {
+    ulimit -n 1048576
     checkpath --directory --owner root /var/log/
     checkpath --file --owner 'EX_USER:EX_GROUP' ${output_log} ${error_log}
 }


### PR DESCRIPTION
## Summary

- Adds `ulimit -n 1048576` to `start_pre()` in the OpenRC template, matching the systemd template's `LimitNOFILE=1048576`
- Fixes https://github.com/bnnanet/serviceman/issues/8

## Test plan

- [ ] Verify generated OpenRC init script includes `ulimit -n 1048576` in `start_pre()`
- [ ] Confirm services using OpenRC get the higher file descriptor limit on start