### PR TITLE
fix(openrc): stop orphan child, rc_ulimit, --nofiles-limit, tmp file collision

### DIFF
--- a/bin/serviceman
+++ b/bin/serviceman
@@ -586,7 +586,8 @@ cmd_add() { (
             "${b_workdir}" \
             "${b_path}" \
             "${b_cap_net_bind}" \
-            "${b_dryrun}"
+            "${b_dryrun}" \
+            "${b_cmdpath}"
         return
     fi
 
@@ -999,6 +1000,7 @@ fn_openrc_add() { (
     a_path="${10}"
     a_cap_net_bind="${11}"
     a_dryrun="${12}"
+    a_cmd="${13}"
 
     if test -n "${a_login_agent}"; then
         echo >&2 "error: '--agent' has no meaning for OpenRC - it doesn't support user launchers"
@@ -1021,7 +1023,8 @@ fn_openrc_add() { (
         sed "s;EX_GROUP;${a_group};g" |
         sed "s;EX_WORKDIR;${a_workdir};g" |
         sed "s;EX_PATH;${a_path};g" |
-        sed "s;EX_SUPERVISE_ARGS;${b_supervise_args};g" > "${a_name}"
+        sed "s;EX_SUPERVISE_ARGS;${b_supervise_args};g" |
+        sed "s;EX_CMD;${a_cmd};g" > "${a_name}"
 
     if test -n "${a_dryrun}"; then
         cat "${a_name}"

--- a/bin/serviceman
+++ b/bin/serviceman
@@ -4,8 +4,8 @@ set -e
 set -u
 
 g_year='2024'
-g_version='v0.9.5'
-g_date='2024-12-23T00:25:00-07:00'
+g_version='v0.9.6'
+g_date='2026-04-20T23:53-06:00'
 g_license='MPL-2.0'
 
 g_scriptdir="$(dirname "${0}")"

--- a/bin/serviceman
+++ b/bin/serviceman
@@ -75,6 +75,7 @@ fn_add_help() { (
     echo ""
     echo "FLAGS"
     echo '    --no-cap-net-bind (Linux only)  do not set cap net bind for privileged ports'
+    echo '    --nofiles-limit <n>  max open file descriptors (default: current hard limit or 262144)'
     echo "    --dryrun  output service file without modifying disk"
     echo "    --force  install even if command or directory does not exist"
     echo "    --daemon (Linux, BSD default)  sudo, install system boot service"
@@ -147,6 +148,12 @@ cmd_add() { (
     b_cap_net_bind=''
     b_dryrun=''
     b_force=''
+    _b_hn="$(ulimit -Hn 2>/dev/null)"
+    case "${_b_hn}" in
+        *[!0-9]*|'') b_open_files="262144" ;;
+        *) b_open_files="${_b_hn}" ;;
+    esac
+    unset _b_hn
 
     b_boot_daemon_set=''
     b_boot_daemon=''
@@ -244,6 +251,14 @@ cmd_add() { (
                 ;;
             --no-cap-net-bind)
                 b_cap_net_bind='n'
+                ;;
+            --nofiles-limit)
+                if test -n "${b_has_arg}"; then
+                    b_open_files="${b_opt_arg}"
+                else
+                    b_open_files="${1:-}"
+                    shift
+                fi
                 ;;
             --dryrun)
                 b_dryrun='y'
@@ -587,7 +602,8 @@ cmd_add() { (
             "${b_path}" \
             "${b_cap_net_bind}" \
             "${b_dryrun}" \
-            "${b_cmdpath}"
+            "${b_cmdpath}" \
+            "${b_open_files}"
         return
     fi
 
@@ -1001,6 +1017,7 @@ fn_openrc_add() { (
     a_cap_net_bind="${11}"
     a_dryrun="${12}"
     a_cmd="${13}"
+    a_nofile="${14}"
 
     if test -n "${a_login_agent}"; then
         echo >&2 "error: '--agent' has no meaning for OpenRC - it doesn't support user launchers"
@@ -1024,7 +1041,8 @@ fn_openrc_add() { (
         sed "s;EX_WORKDIR;${a_workdir};g" |
         sed "s;EX_PATH;${a_path};g" |
         sed "s;EX_SUPERVISE_ARGS;${b_supervise_args};g" |
-        sed "s;EX_CMD;${a_cmd};g" > "${a_name}"
+        sed "s;EX_CMD;${a_cmd};g" |
+        sed "s;EX_NOFILE;${a_nofile};g" > "${a_name}"
 
     if test -n "${a_dryrun}"; then
         cat "${a_name}"

--- a/bin/serviceman
+++ b/bin/serviceman
@@ -1042,16 +1042,17 @@ fn_openrc_add() { (
         sed "s;EX_PATH;${a_path};g" |
         sed "s;EX_SUPERVISE_ARGS;${b_supervise_args};g" |
         sed "s;EX_CMD;${a_cmd};g" |
-        sed "s;EX_NOFILE;${a_nofile};g" > "${a_name}"
+        sed "s;EX_NOFILE;${a_nofile};g" > "${a_name}.openrc.tmp"
 
     if test -n "${a_dryrun}"; then
-        cat "${a_name}"
+        cat "${a_name}.openrc.tmp"
+        rm -f "${a_name}.openrc.tmp"
         return 0
     fi
 
     echo "Initializing OpenRC service..." >&2
     echo "    create /etc/init.d/${a_name}" >&2
-    ${cmd_sudo} mv "${a_name}" "/etc/init.d/${a_name}"
+    ${cmd_sudo} mv "${a_name}.openrc.tmp" "/etc/init.d/${a_name}"
     ${cmd_sudo} chmod 0755 "/etc/init.d/${a_name}"
     ${cmd_sudo} chown -R root:root "/etc/init.d/${a_name}"
 

--- a/share/serviceman/template.openrc
+++ b/share/serviceman/template.openrc
@@ -8,6 +8,7 @@ description="EX_DESC"
 supervisor="supervise-daemon"
 output_log="/var/log/EX_NAME"
 error_log="/var/log/EX_NAME"
+rc_ulimit="-n EX_NOFILE"
 
 depend() {
     need net

--- a/share/serviceman/template.openrc
+++ b/share/serviceman/template.openrc
@@ -30,6 +30,7 @@ start() {
         --pidfile /run/${RC_SVCNAME}.pid \
         --respawn-delay 5 \
         --respawn-max 51840 \
+        --respawn-period 259201 \
         EX_SUPERVISE_ARGS \
         -- \
         EX_POSIX_ARGS
@@ -40,5 +41,8 @@ stop() {
     ebegin "Stopping ${name}"
     supervise-daemon ${name} --stop \
         --pidfile /run/${RC_SVCNAME}.pid
+    start-stop-daemon --stop --quiet \
+        --retry TERM/20/KILL/1 \
+        --exec 'EX_CMD' 2>/dev/null || true
     eend $?
 }


### PR DESCRIPTION
Collects several OpenRC fixes for v0.9.6.

## Changes

- **Orphan child on stop/restart** (`e34c508`): `supervise-daemon --stop` kills the supervisor but leaves the child alive. Added `start-stop-daemon --stop --retry TERM/20/KILL/1 --exec EX_CMD` in `stop()`. Also fixes the `respawn-period` warning by setting `--respawn-period 259201`.

- **rc_ulimit instead of ulimit** (`ca012f1`): `ulimit` in `start_pre()` sets the limit on the init shell, not the child. `rc_ulimit="-n EX_NOFILE"` is the OpenRC-native mechanism and applies correctly.

- **--nofiles-limit flag** (`d1fdee5`, `95e6757`): Replaces the hardcoded `1048576` (which exceeds many systems' hard limit) with a value derived from `ulimit -Hn` at generation time, falling back to 262144 if the limit is `unlimited` or unavailable. Override with `serviceman add --nofiles-limit <n>`.

- **Temp file collision** (`cd4ad83`): The OpenRC init script was written to a bare `${name}` temp file in CWD — could overwrite a same-named binary. Now uses `${name}.openrc.tmp`. Fixes #15.

## Test plan

- [x] `rc-service payd-vault restart` — no orphan child, fresh PIDs after restart
- [x] No `increase respawn-period` warning in logs
- [x] `/proc/<pid>/limits` shows `Max open files: 524288 / 524288` after restart
- [x] `serviceman add --dryrun` produces `rc_ulimit="-n <system-hard-limit>"`
- [x] `serviceman add --nofiles-limit 262144 --dryrun` produces `rc_ulimit="-n 262144"`
- [x] Running `serviceman add` from a dir containing a same-named binary does not overwrite it