### PR TITLE
fix: use install to place service files and reduce sudo calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,30 @@ EXAMPLES
     shell:   serviceman add --name 'foo' -- ./foo.sh --bar ./baz
 ```
 
+# Sudo / Permissions
+
+`serviceman add --daemon` uses `sudo` internally for two categories of operations:
+
+**File placement** — uses `install`. Can be granted `NOPASSWD`:
+
+```sudoers
+# /etc/sudoers.d/serviceman
+%wheel ALL=(ALL) NOPASSWD: /usr/bin/install
+```
+
+**Service control** — always requires sudo (these modify kernel/init state):
+
+```sudoers
+# OpenRC (Alpine, Gentoo, Devuan)
+%wheel ALL=(ALL) NOPASSWD: /sbin/rc-service
+%wheel ALL=(ALL) NOPASSWD: /sbin/rc-update
+
+# systemd (Debian, Ubuntu, Arch, Fedora, etc.)
+%wheel ALL=(ALL) NOPASSWD: /usr/bin/systemctl
+```
+
+With these in place, `serviceman add` runs without a password prompt from end to end.
+
 # Changes in v1.0
 
 -   add OpenRC (Alpine Linux) support

--- a/bin/serviceman
+++ b/bin/serviceman
@@ -94,6 +94,13 @@ fn_add_help() { (
     echo "    --user <username>  defaults to '$(id -u -n)'"
     echo '    --workdir <dirpath>  where the command runs, defaults to current directory'
     echo ""
+    echo "SUDO (--daemon mode)"
+    echo "    File placement uses 'install' — grantable NOPASSWD:"
+    echo "        NOPASSWD: /usr/bin/install"
+    echo "    Service control always requires sudo (cannot run unprivileged):"
+    echo "        NOPASSWD: /sbin/rc-service, /sbin/rc-update  # OpenRC (Alpine, Gentoo, Devuan)"
+    echo "        NOPASSWD: /usr/bin/systemctl                  # systemd"
+    echo ""
     echo "DEPRECATED (DO NOT USE)"
     echo "    --system  alias of --daemon, for compatibility"
     echo "    --username  alias of --user, for compatibility"

--- a/bin/serviceman
+++ b/bin/serviceman
@@ -773,16 +773,11 @@ fn_launchctl_add() { (
         echo "Initializing launchctl service..."
         echo "    create ${b_launcher_path}/${a_name}.plist"
     } >&2
-    ${b_sudo} mv "${a_name}.plist" "${b_launcher_path}/${a_name}.plist"
-    ${b_sudo} chmod 0644 "${b_launcher_path}/${a_name}.plist"
-    ${b_sudo} chown -R "${a_user}:${a_group}" "${b_launcher_path}/${a_name}.plist"
+    ${b_sudo} install -m 0644 -o "${a_user}" -g "${a_group}" "${a_name}.plist" "${b_launcher_path}/${a_name}.plist"
 
     echo "    create ~/.local/share/${a_name}/var/log/" >&2
-    ${b_sudo} mkdir -p "${b_log_prefix}/var/log/"
-    ${b_sudo} chmod 0750 "${b_log_prefix}/var/log/"
-    ${b_sudo} touch "${b_log_prefix}/var/log/${a_name}.log"
-    ${b_sudo} chmod 0640 "${b_log_prefix}/var/log/${a_name}.log"
-    ${b_sudo} chown -R "${a_user}":"${a_group}" "${b_log_prefix}/var/log/${a_name}.log"
+    ${b_sudo} install -d -m 0750 "${b_log_prefix}/var/log/"
+    ${b_sudo} install -m 0640 -o "${a_user}" -g "${a_group}" /dev/null "${b_log_prefix}/var/log/${a_name}.log"
 
     echo "   ${b_sudo} launchctl unload -w '${b_launcher_path}/${a_name}.plist'" >&2
     ${b_sudo} launchctl unload -w "${b_launcher_path}/${a_name}.plist" 2> /dev/null || true
@@ -937,14 +932,13 @@ fn_systemd_add() { (
         echo "Initializing systemd service..."
         echo "    create ${b_service_path}/${a_name}.service"
     } >&2
-    ${b_sudo} mv "${a_name}.service" "${b_service_path}/${a_name}.service"
-    ${b_sudo} chmod 0644 "${b_service_path}/${a_name}.service"
     if test -z "${a_login_agent}"; then
-        ${cmd_sudo} chown -R root:root "${b_service_path}/${a_name}.service"
-
+        ${b_sudo} install -m 0644 -o root -g root "${a_name}.service" "${b_service_path}/${a_name}.service"
         echo "    ${cmd_sudo} systemctl${b_usertype} restart systemd-journald" >&2
         #shellcheck disable=SC2086
         ${cmd_sudo} systemctl${b_usertype} restart systemd-journald
+    else
+        ${b_sudo} install -m 0644 "${a_name}.service" "${b_service_path}/${a_name}.service"
     fi
 
     echo "   ${b_sudo} systemctl${b_usertype} daemon-reload" >&2
@@ -1052,22 +1046,17 @@ fn_openrc_add() { (
 
     echo "Initializing OpenRC service..." >&2
     echo "    create /etc/init.d/${a_name}" >&2
-    ${cmd_sudo} mv "${a_name}.openrc.tmp" "/etc/init.d/${a_name}"
-    ${cmd_sudo} chmod 0755 "/etc/init.d/${a_name}"
-    ${cmd_sudo} chown -R root:root "/etc/init.d/${a_name}"
+    ${cmd_sudo} install -m 0755 -o root -g root "${a_name}.openrc.tmp" "/etc/init.d/${a_name}"
 
     echo "    create /etc/logrotate.d/${a_name}" >&2
     # shellcheck disable=SC2002
     cat "${g_scriptdir}/../share/serviceman/template.logrotate" |
-        sed "s;EX_NAME;${a_name};g" |
-        ${cmd_sudo} tee "/etc/logrotate.d/${a_name}" > /dev/null
-    ${cmd_sudo} chmod 0640 "/etc/logrotate.d/${a_name}"
-    ${cmd_sudo} chown -R root:root "/etc/logrotate.d/${a_name}"
+        sed "s;EX_NAME;${a_name};g" > "${a_name}.logrotate.tmp"
+    ${cmd_sudo} install -m 0640 -o root -g root "${a_name}.logrotate.tmp" "/etc/logrotate.d/${a_name}"
+    rm -f "${a_name}.logrotate.tmp"
 
     echo "    create /var/log/${a_name}" >&2
-    ${cmd_sudo} touch "/var/log/${a_name}"
-    ${cmd_sudo} chmod 0640 "/var/log/${a_name}"
-    ${cmd_sudo} chown -R "${a_user}":"${a_group}" "/var/log/${a_name}"
+    ${cmd_sudo} install -m 0640 -o "${a_user}" -g "${a_group}" /dev/null "/var/log/${a_name}"
 
     echo "    rc-service '${a_name}' restart" >&2
     ${cmd_sudo} rc-service "${a_name}" restart &&


### PR DESCRIPTION
Fixes #16

Replace `mv` + `chmod` + `chown` sequences with a single `install` call for each file placement. Reduces the number of sudo invocations per `serviceman add` from up to 11 down to 4 (one per file: init.d, logrotate, log file, plus the mandatory service-control calls).

| Location | Before | After |
|---|---|---|
| launchctl plist | mv + chmod + chown = 3 | install = 1 |
| launchctl log dir | mkdir + chmod = 2 | install -d = 1 |
| launchctl log file | touch + chmod + chown = 3 | install /dev/null = 1 |
| systemd service | mv + chmod + chown = 3 | install = 1 |
| openrc init.d | mv + chmod + chown = 3 | install = 1 |
| openrc logrotate | tee + chmod + chown = 3 | temp + install = 1 |
| openrc log file | touch + chmod + chown = 3 | install /dev/null = 1 |

The logrotate file now uses a `.logrotate.tmp` intermediary so the sed pipeline writes to a local file before `install` places it with correct owner and mode.

## Test plan

- [x] `serviceman add` on live payd-vault instance completes without password prompt for file placement
- [x] `/etc/init.d/payd-vault` — `0755 root:root` ✓
- [x] `/etc/logrotate.d/payd-vault` — `0640 root:root` ✓
- [x] `/var/log/payd-vault` — `0640 pay:pay` ✓
- [x] Service restarted successfully; `curl /api/version` responds