### PR TITLE
fix: clean up temp files after install in all service managers

### DIFF
--- a/bin/serviceman
+++ b/bin/serviceman
@@ -4,8 +4,8 @@ set -e
 set -u
 
 g_year='2024'
-g_version='v1.0.0'
-g_date='2026-04-21T00:28-06:00'
+g_version='v1.0.2'
+g_date='2026-05-08T13:49-06:00'
 g_license='MPL-2.0'
 
 g_scriptdir="$(dirname "${0}")"
@@ -714,6 +714,7 @@ fn_launchctl_add() { (
 
     if test -n "${a_dryrun}"; then
         cat "${a_name}.plist"
+        rm -f "${a_name}.plist"
         return 0
     fi
 
@@ -722,6 +723,7 @@ fn_launchctl_add() { (
         echo "    create ${b_launcher_path}/${a_name}.plist"
     } >&2
     ${b_sudo} install -m 0644 -o "${a_user}" -g "${a_group}" "${a_name}.plist" "${b_launcher_path}/${a_name}.plist"
+    rm -f "${a_name}.plist"
 
     echo "    create ~/.local/share/${a_name}/var/log/" >&2
     ${b_sudo} install -d -m 0750 "${b_log_prefix}/var/log/"
@@ -873,6 +875,7 @@ fn_systemd_add() { (
 
     if test -n "${a_dryrun}"; then
         cat "${a_name}.service"
+        rm -f "${a_name}.service"
         return 0
     fi
 
@@ -888,6 +891,7 @@ fn_systemd_add() { (
     else
         ${b_sudo} install -m 0644 "${a_name}.service" "${b_service_path}/${a_name}.service"
     fi
+    rm -f "${a_name}.service"
 
     echo "   ${b_sudo} systemctl${b_usertype} daemon-reload" >&2
     #shellcheck disable=SC2086
@@ -995,6 +999,7 @@ fn_openrc_add() { (
     echo "Initializing OpenRC service..." >&2
     echo "    create /etc/init.d/${a_name}" >&2
     ${cmd_sudo} install -m 0755 -o root -g root "${a_name}.openrc.tmp" "/etc/init.d/${a_name}"
+    rm -f "${a_name}.openrc.tmp"
 
     echo "    create /etc/logrotate.d/${a_name}" >&2
     # shellcheck disable=SC2002


### PR DESCRIPTION
## Summary

- **systemd:** `${name}.service` temp file left in CWD after `install`
- **OpenRC:** `${name}.openrc.tmp` temp file left in CWD after `install`  
- **launchctl:** `${name}.plist` temp file left in CWD after `install`

All three `add` functions write a templated file to the current working directory, `install` it to the system destination, but never remove the source. The OpenRC logrotate temp file already had proper cleanup — this extends that pattern to all main service files.

Also fixes dryrun paths for systemd and launchctl (OpenRC dryrun was already correct).

## Changes

Added `rm -f` after each `install` command, and in dryrun paths where the file is `cat`'d to stdout. Bumped version to v1.0.2."