### PR TITLE
fix(systemd): add restart defaults to user service template

### DIFF
--- a/share/serviceman/template.user.service
+++ b/share/serviceman/template.user.service
@@ -6,10 +6,15 @@ Description=EX_TITLE EX_DESC
 Documentation=EX_URL
 
 [Service]
+# never stop trying to restart a failed service
+StartLimitIntervalSec=0
+
+# allow the restart to delay if it's unsuccessful
+# warning: keep the max low as the backoff never resets
 Restart=always
-RestartSec=3
-RestartSteps=5
-RestartMaxDelaySec=300
+RestartSec=0.1
+RestartSteps=10
+RestartMaxDelaySec=5
 
 Environment="PATH=EX_PATH"
 WorkingDirectory=EX_WORKDIR


### PR DESCRIPTION
## Changes

The systemd user service template was missed in #31. Apply the same restart defaults:

| Setting | Before | After |
|---|---|---|
| `StartLimitIntervalSec` | _(not set)_ | `0` |
| `RestartSec` | `3` | `0.1` |
| `RestartSteps` | `5` | `10` |
| `RestartMaxDelaySec` | `300` | `5` |

## Rationale

- **`StartLimitIntervalSec=0`** — never stop trying to restart a failed service.
- **`RestartSec=0.1`** — snappy 100ms retry instead of 3s idle.
- **`RestartSteps=10`** — up to 10 consecutive restart attempts before giving up.
- **`RestartMaxDelaySec=5`** — cap the exponential backoff at 5s. With only 10 steps this never actually hits the cap, but it documents the intent.

## Notes

Comments added inline explaining each setting's purpose.
