### PR TITLE
fix: list OpenRC services from init.d

### DIFF
--- a/bin/serviceman
+++ b/bin/serviceman
@@ -1143,7 +1143,7 @@ cmd_list() { (
 	fi
 	if command -v rc-update > /dev/null; then
 		b_header='!/sbin/openrc-run'
-		b_path="/etc/systemd/system"
+		b_path="/etc/init.d"
 		if test -n "${b_login_agent}"; then
 			b_path=''
 			echo >&2 "error: '--agent' has no meaning for OpenRC - it doesn't support user launchers"

--- a/bin/serviceman
+++ b/bin/serviceman
@@ -4,8 +4,8 @@ set -e
 set -u
 
 g_year='2024'
-g_version='v1.1.0'
-g_date='2026-07-03T13:31-06:00'
+g_version='v1.1.3'
+g_date='2026-08-25T05:30-06:00'
 g_license='MPL-2.0'
 
 g_scriptdir=$(dirname "${0}")


### PR DESCRIPTION
## Summary

- fix `serviceman list` using `/etc/systemd/system` when OpenRC is detected
- list OpenRC services from `/etc/init.d`

## Verification

- `shellcheck -S warning bin/serviceman`
- `sh -n bin/serviceman`
- simulated Linux/OpenRC environment; `serviceman list --all` reports `/etc/init.d`

Observed on Alpine 3.18: `rc-update` was available, but `serviceman list` incorrectly printed `/etc/systemd/system`.
